### PR TITLE
Store file location url instead of stream url

### DIFF
--- a/app/models/concerns/hyrax/active_encode/file_set_behavior.rb
+++ b/app/models/concerns/hyrax/active_encode/file_set_behavior.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'active_fedora/with_metadata/external_file_uri_schema'
+require 'active_fedora/with_metadata/file_location_uri_schema'
 
 module Hyrax
   module ActiveEncode
@@ -26,7 +26,7 @@ module Hyrax
       end
 
       def derivatives_metadata
-        derivatives.collect { |f| { id: f.id, label: f.label.first, external_file_uri: f.external_file_uri.first } }
+        derivatives.collect { |f| { id: f.id, label: f.label.first, file_location_uri: f.file_location_uri.first } }
       end
     end
   end

--- a/app/services/hyrax/active_encode/active_encode_derivative_service.rb
+++ b/app/services/hyrax/active_encode/active_encode_derivative_service.rb
@@ -51,7 +51,7 @@ module Hyrax
       # What should this return?
       def derivative_url(file_label)
         derivative = file_set.derivatives.find { |d| d.label.first == file_label }
-        derivative.nil? ? nil : derivative.external_file_uri.first
+        derivative.nil? ? nil : derivative.file_location_uri.first
       end
 
       def valid?

--- a/app/services/hyrax/active_encode/persist_active_encode_derivatives.rb
+++ b/app/services/hyrax/active_encode/persist_active_encode_derivatives.rb
@@ -20,7 +20,7 @@ module Hyrax
       def self.create_pcdm_file(output, file_set)
         pcdm_file = file_set.build_derivative
         pcdm_file.label = output.label
-        pcdm_file.external_file_uri = output.url
+        pcdm_file.file_location_uri = output.url
         pcdm_file.content = ''
         file_set.save!
       end

--- a/app/services/hyrax/active_encode/persist_active_encode_derivatives.rb
+++ b/app/services/hyrax/active_encode/persist_active_encode_derivatives.rb
@@ -9,11 +9,7 @@ module Hyrax
       # @option directives [String] file_set_id the id of the file set to add the derivative
       def self.call(output, directives)
         file_set = ActiveFedora::Base.find(directives[:file_set_id])
-        if directives[:local_streaming]
-          old_url = output.url
-          move_derivative(output, file_set)
-          output.url = Hyrax::Engine.routes.url_helpers.download_path(file_set, file: File.basename(old_url))
-        end
+        output.url = move_derivative(output, file_set) if directives[:local_streaming]
         create_pcdm_file(output, file_set)
       end
 

--- a/lib/active_fedora/with_metadata/file_location_uri_schema.rb
+++ b/lib/active_fedora/with_metadata/file_location_uri_schema.rb
@@ -5,7 +5,7 @@
 module ActiveFedora::WithMetadata
   class ExternalFileUriSchema < ActiveTriples::Schema
     # Don't cast to keep values as RDF::URI instead of RDF::Resource
-    property :external_file_uri, predicate: ::RDF::Vocab::EBUCore.locator, cast: false do |index|
+    property :file_location_uri, predicate: ::RDF::Vocab::EBUCore.locator, cast: false do |index|
       index.as :stored_searchable
     end
   end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -22,7 +22,7 @@ describe FileSet do
   let(:derivative) do
     file_set.build_derivative.tap do |d|
       d.label = 'high'
-      d.external_file_uri = 'http://test.file'
+      d.file_location_uri = 'http://test.file'
       d.content = ''
     end
   end
@@ -60,7 +60,7 @@ describe FileSet do
   end
 
   describe '#derivatives_metadata' do
-    let(:derivatives_metadata) { [{ id: derivative.id, label: 'high', external_file_uri: 'http://test.file' }] }
+    let(:derivatives_metadata) { [{ id: derivative.id, label: 'high', file_location_uri: 'http://test.file' }] }
     let(:indexer) { file_set.class.indexer.new(file_set) }
 
     before do

--- a/spec/services/active_encode_derivative_service_spec.rb
+++ b/spec/services/active_encode_derivative_service_spec.rb
@@ -121,7 +121,7 @@ describe Hyrax::ActiveEncode::ActiveEncodeDerivativeService do
     let(:derivative) do
       file_set.build_derivative.tap do |d|
         d.label = 'high'
-        d.external_file_uri = external_uri
+        d.file_location_uri = external_uri
       end
     end
 

--- a/spec/services/persist_active_encode_derivatives_spec.rb
+++ b/spec/services/persist_active_encode_derivatives_spec.rb
@@ -26,7 +26,7 @@ describe Hyrax::ActiveEncode::PersistActiveEncodeDerivatives do
   let(:derivative) do
     file_set.build_derivative.tap do |d|
       d.label = label
-      d.external_file_uri = url
+      d.file_location_uri = url
       d.content = ''
     end
   end
@@ -67,7 +67,7 @@ describe Hyrax::ActiveEncode::PersistActiveEncodeDerivatives do
         it "creates pcdm file" do
           call_persist
           expect(pcdm_file.label).to eq Array[label]
-          expect(pcdm_file.external_file_uri).to eq Array[downpath]
+          expect(pcdm_file.file_location_uri).to eq Array[downpath]
           expect(pcdm_file.content).to eq ''
         end
       end
@@ -93,7 +93,7 @@ describe Hyrax::ActiveEncode::PersistActiveEncodeDerivatives do
         it "creates pcdm file" do
           call_persist
           expect(pcdm_file.label).to eq Array[label]
-          expect(pcdm_file.external_file_uri).to eq Array[downpath]
+          expect(pcdm_file.file_location_uri).to eq Array[downpath]
           expect(pcdm_file.content).to eq ''
         end
       end
@@ -110,7 +110,7 @@ describe Hyrax::ActiveEncode::PersistActiveEncodeDerivatives do
       it "creates pcdm file" do
         call_persist
         expect(pcdm_file.label).to eq Array[label]
-        expect(pcdm_file.external_file_uri).to eq Array[url]
+        expect(pcdm_file.file_location_uri).to eq Array[url]
         expect(pcdm_file.content).to eq ''
       end
     end

--- a/spec/services/persist_active_encode_derivatives_spec.rb
+++ b/spec/services/persist_active_encode_derivatives_spec.rb
@@ -46,7 +46,6 @@ describe Hyrax::ActiveEncode::PersistActiveEncodeDerivatives do
     context 'for local streaming' do
       let(:filename) { 'sample.mp4' }
       let(:refpath) { Hyrax::DerivativePath.derivative_path_for_reference(file_set.id, filename) }
-      let(:downpath) { Hyrax::Engine.routes.url_helpers.download_path(file_set, file: filename) }
 
       context 'with a local output derivative' do
         let(:file) { Tempfile.new }
@@ -61,13 +60,13 @@ describe Hyrax::ActiveEncode::PersistActiveEncodeDerivatives do
 
         it 'updates the output url to point to the designated download directory' do
           call_persist
-          expect(output.url).to eq downpath
+          expect(output.url).to eq refpath
         end
 
         it "creates pcdm file" do
           call_persist
           expect(pcdm_file.label).to eq Array[label]
-          expect(pcdm_file.file_location_uri).to eq Array[downpath]
+          expect(pcdm_file.file_location_uri).to eq Array[refpath]
           expect(pcdm_file.content).to eq ''
         end
       end
@@ -87,13 +86,13 @@ describe Hyrax::ActiveEncode::PersistActiveEncodeDerivatives do
 
         it 'updates the output url to point to the designated download directory' do
           call_persist
-          expect(output.url).to eq downpath
+          expect(output.url).to eq refpath
         end
 
         it "creates pcdm file" do
           call_persist
           expect(pcdm_file.label).to eq Array[label]
-          expect(pcdm_file.file_location_uri).to eq Array[downpath]
+          expect(pcdm_file.file_location_uri).to eq Array[refpath]
           expect(pcdm_file.content).to eq ''
         end
       end


### PR DESCRIPTION
Part of https://github.com/samvera-labs/avalon-bundle/issues/234.

This PR stores the file location in the derivative object to follow the pattern established by Hyrax for mapping images to service urls via a lambda:
https://github.com/samvera/hyrax/blob/5a9d1be16ee1a9150646384471992b03aab527a5/lib/generators/hyrax/templates/config/initializers/hyrax.rb#L139-L142

Follow on work to this PR is adding the lambda to `hyrax-iiif_av`.