### PR TITLE
Store global id passed back from hydra-derivatives

### DIFF
--- a/app/models/concerns/hyrax/active_encode/file_set_behavior.rb
+++ b/app/models/concerns/hyrax/active_encode/file_set_behavior.rb
@@ -7,11 +7,11 @@ module Hyrax
       extend ActiveSupport::Concern
 
       included do
-        # Is this too late?  Has the ActiveFedora::File metadata schema been frozen already?
-        ActiveFedora::WithMetadata::DefaultMetadataClassFactory.file_metadata_schemas += [ActiveFedora::WithMetadata::ExternalFileUriSchema]
+        property :encode_global_id, predicate: ::RDF::URI.new('http://avalonmediasystem.org/rdf/vocab/transcoding#workflowId'), multiple: false do |index|
+          index.as :symbol
+        end
 
-        # The following doesn't work because through isn't allowed on directly_contains even though it is on directly_contains_one
-        # directly_contains :derivatives, through: :files, type: ::RDF::URI('http://pcdm.org/use#ServiceFile'), class_name: 'Hydra::PCDM::File'
+        ActiveFedora::WithMetadata::DefaultMetadataClassFactory.file_metadata_schemas += [ActiveFedora::WithMetadata::FileLocationUriSchema]
       end
 
       def build_derivative

--- a/app/services/hyrax/active_encode/persist_active_encode_derivatives.rb
+++ b/app/services/hyrax/active_encode/persist_active_encode_derivatives.rb
@@ -9,6 +9,7 @@ module Hyrax
       # @option directives [String] file_set_id the id of the file set to add the derivative
       def self.call(output, directives)
         file_set = ActiveFedora::Base.find(directives[:file_set_id])
+        file_set.encode_global_id ||= directives[:encode_global_id]
         output.url = move_derivative(output, file_set) if directives[:local_streaming]
         create_pcdm_file(output, file_set)
       end

--- a/lib/active_fedora/with_metadata/file_location_uri_schema.rb
+++ b/lib/active_fedora/with_metadata/file_location_uri_schema.rb
@@ -3,7 +3,7 @@
 # added to it. This is most commonly used with ActiveFedora::File, when we want
 # to add rdf triples to a non-rdf resource and have them persisted.
 module ActiveFedora::WithMetadata
-  class ExternalFileUriSchema < ActiveTriples::Schema
+  class FileLocationUriSchema < ActiveTriples::Schema
     # Don't cast to keep values as RDF::URI instead of RDF::Resource
     property :file_location_uri, predicate: ::RDF::Vocab::EBUCore.locator, cast: false do |index|
       index.as :stored_searchable

--- a/spec/services/persist_active_encode_derivatives_spec.rb
+++ b/spec/services/persist_active_encode_derivatives_spec.rb
@@ -113,5 +113,16 @@ describe Hyrax::ActiveEncode::PersistActiveEncodeDerivatives do
         expect(pcdm_file.content).to eq ''
       end
     end
+
+    context 'with global id' do
+      let(:local_streaming) { false }
+      let(:global_id) { "gid://ActiveEncode/ActiveEncode::Base/1" }
+      let(:directives) { { local_streaming: local_streaming, file_set_id: file_set.id, encode_global_id: global_id } }
+
+      it "persists it on the file set" do
+        call_persist
+        expect(file_set.reload.encode_global_id).to eq global_id
+      end
+    end
   end
 end


### PR DESCRIPTION
Also fix class naming issue.

This PR doesn't depend on the global id being passed back but will store it if it is.  The passing back of the global id happens in hydra-derivatives: https://github.com/samvera/hydra-derivatives/pull/193